### PR TITLE
Accept multiple paths on the command line

### DIFF
--- a/mkvstrip.py
+++ b/mkvstrip.py
@@ -358,8 +358,8 @@ def main(params=None):
     """
     # Create Parser to parse the required arguments
     parser = argparse.ArgumentParser(description="Strips unnecessary tracks from MKV files.")
-    parser.add_argument("path", action=RealPath,
-                        help="Where your MKV files are stored. Can be a directory or a file.")
+    parser.add_argument("paths", nargs='+',
+                        help="Where your MKV files are stored. Can be a directories or files.")
     parser.add_argument("-t", "--dry-run", action="store_true", help="Enable mkvmerge dry run for testing.")
     parser.add_argument("-b", "--mkvmerge-bin", default=BIN_DEFAULT,
                         action="store", metavar="path",
@@ -381,10 +381,12 @@ def main(params=None):
     # Iterate over all found mkv files
     print("Searching for MKV files to process.")
     print("Warning: This may take some time...")
-    for mkv_file in walk_directory(cli_args.path):
-        mkv_obj = MKVFile(mkv_file)
-        if mkv_obj.remux_required:
-            mkv_obj.remove_tracks()
+    for path in cli_args.paths:
+        path = os.path.realpath(path)
+        for mkv_file in walk_directory(path):
+            mkv_obj = MKVFile(mkv_file)
+            if mkv_obj.remux_required:
+                mkv_obj.remove_tracks()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change enables mkvstrip to accept multiple paths on the command line and it runs through each of them. It makes it easier to strip multiple directories at once.