### PR TITLE
Verbose output

### DIFF
--- a/mkvstrip.py
+++ b/mkvstrip.py
@@ -375,7 +375,7 @@ def main(params=None):
                         help="If specified, defines subtitle languages to retain. See description of --language "
                              "for syntax.")
     parser.add_argument("-v", "--verbose", action="store_true",
-                        default=False, help="Verbose output about.")
+                        default=False, help="Verbose output.")
 
     # Parse the list of given arguments
     globals()["cli_args"] = parser.parse_args(params)

--- a/mkvstrip.py
+++ b/mkvstrip.py
@@ -374,6 +374,8 @@ def main(params=None):
                         dest="subs_language", default=None,
                         help="If specified, defines subtitle languages to retain. See description of --language "
                              "for syntax.")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        default=False, help="Verbose output about.")
 
     # Parse the list of given arguments
     globals()["cli_args"] = parser.parse_args(params)
@@ -382,6 +384,8 @@ def main(params=None):
     print("Searching for MKV files to process.")
     print("Warning: This may take some time...")
     for mkv_file in walk_directory(cli_args.path):
+        if cli_args.verbose:
+            print("Checking", mkv_file)
         mkv_obj = MKVFile(mkv_file)
         if mkv_obj.remux_required:
             mkv_obj.remove_tracks()


### PR DESCRIPTION
This change enables optional more verbose output for mkvstrip. 

The one example I provide here I find a bit useful when scanning lots of files in a big directory to monitor progress through the directory. Or multiple directories as in the [multiple-paths PR](https://github.com/willforde/mkvstrip/pull/6)
