### PR TITLE
The Nude Bomb (recursive stripping)

### DIFF
--- a/langfiles.py
+++ b/langfiles.py
@@ -1,0 +1,38 @@
+"""module for reading lang files."""
+import os
+
+LANGS_FNS = ('lang', 'langs', '.lang', '.langs')
+
+
+def read_lang_files(lang_roots, path):
+    """Read the lang files and parse languages.
+       lang_roots is a dictionary to cache paths and languages to avoid
+       reparsing the same language files.
+    """
+    if path not in lang_roots:
+        lang_roots[path] = set()
+        for fn in LANGS_FNS:
+            try:
+                langpath = os.path.join(path, fn)
+                newlangs = set()
+                with open(langpath, 'r') as langfile:
+                    for line in langfile:
+                        linelangs = set(line.strip().split(','))
+                        newlangs = newlangs.union(linelangs)
+                lang_roots[path] = lang_roots[path].union(newlangs)
+            except FileNotFoundError:
+                pass
+    return lang_roots[path]
+
+
+def get_langs(root_path, path, lang_roots, cli_args):
+    """Get the languages from this dir and parent dirs."""
+    langs = set(cli_args.language)
+
+    while True:
+        new_langs = read_lang_files(lang_roots, path)
+        langs = langs.union(new_langs)
+        if path == root_path:
+            break
+        path = os.path.dirname(path)
+    return langs

--- a/mkvstrip.py
+++ b/mkvstrip.py
@@ -357,8 +357,8 @@ def strip_path(root, filename, langs):
     fullpath = os.path.join(root, filename)
 
     for mkv_file in walk_directory(fullpath):
-        if cli_args.verbose:
-            print("Checking", fullpath)
+        #if cli_args.verbose:
+        #    print("Checking", fullpath)
         mkv_obj = MKVFile(mkv_file, langs)
         if mkv_obj.remux_required:
             mkv_obj.remove_tracks()


### PR DESCRIPTION
This is a big change. It enables recursion through all subdirectories for entire movie collections.

Because an entire directory tree of mkvs may have various different language configurations I elected to store the particular languages to be preserved, persistently in external files set within each directory. The language files act hierarchically. If you declare the ‘jpn’ language at the top of the tree, it cascades and preserves ‘jpn’ for all subdirectories below it. For instance, you could place one file in the Cowboy Bebob root directory and it would apply to all episodes and seasons below it.

Language files are comma delimited just like the command line option. So a file that contains "jpn,fre,eng" is valid.

You'll see that I allow four different language file names because people may make spelling mistakes or prefer the files to be hidden.

I currently use this for managing my entire movie and TV collection.