### PR TITLE
Nudebomb timestamps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,3 +75,10 @@ CLI Arguments
                             all subtitles.
     -v, --verbose         Verbose output.
     -r, --recurse         Recurse through all paths on the command line.
+
+Lang Files
+----------
+Lang files are primarily for use with the `--recurse` option. They are persistent files on disk that will be parsed by mkvstrip and apply their languages to keep to all the mkvs in the current directory and all sub directories.
+Lang files may be named: 'lang', 'langs', '.lang', or '.langs'
+They may include comma separatedlist of languages to retain exactly like the `-l` option.
+e.g. You may have an entire TV collecttion with a root lang file containing the `eng` language. Under that directory you may have a TV show with lang file containing `jpn` and multiple season directories under that. All seasons of the TV show would then retain the `eng,jpn` languages, while other TV shows would only retain `eng`.

--- a/README.rst
+++ b/README.rst
@@ -46,21 +46,21 @@ Windows::
 CLI Arguments
 -------------
 ::
-
-    mkvstrip.py [-h] [-t] [-b path] -l lang [-s subs-lang] path
+    usage: mkvstrip.py [-h] [-t] [-b path] -l lang [-s subs-lang] [-n] [-v] [-r]
+                    paths [paths ...]
 
     Strips unnecessary tracks from MKV files.
 
     positional arguments:
-      path                  Where your MKV files are stored. Can be a directory or
-                            a file.
+    paths                 Where your MKV files are stored. Can be a directories
+                            or files.
 
     optional arguments:
-      -h, --help            show this help message and exit
-      -t, --dry-run         Enable mkvmerge dry run for testing.
-      -b path, --mkvmerge-bin path
+    -h, --help            show this help message and exit
+    -t, --dry-run         Enable mkvmerge dry run for testing.
+    -b path, --mkvmerge-bin path
                             The path to the MKVMerge executable.
-      -l lang, --language lang
+    -l lang, --language lang
                             Comma-separated list of subtitle and audio languages
                             to retain. E.g. eng,fre. Language codes can be either
                             the 3 letters bibliographic ISO-639-2 form (like "fre"
@@ -68,7 +68,10 @@ CLI Arguments
                             dash and a country code for specialities in languages
                             (like "fre-ca" for Canadian French). Country codes are
                             the same as used for internet domains.
-      -s subs-lang, --subs-language subs-lang
+    -s subs-lang, --subs-language subs-lang
                             If specified, defines subtitle languages to retain.
                             See description of --language for syntax.
-
+    -n, --no-subtitles    If no subtitles match the languages to retain, strip
+                            all subtitles.
+    -v, --verbose         Verbose output.
+    -r, --recurse         Recurse through all paths on the command line.

--- a/mkvstrip.py
+++ b/mkvstrip.py
@@ -370,8 +370,8 @@ def strip_path(root, filename, langs):
     # Iterate over all found mkv files
     if not filename.endswith('mkv'):
         return
-    fullpath = os.path.join(root, filename)
 
+    fullpath = os.path.join(root, filename)
     for mkv_file in walk_directory(fullpath):
         if cli_args.verbose:
             print("Checking", fullpath)

--- a/mkvstrip.py
+++ b/mkvstrip.py
@@ -353,7 +353,7 @@ class MKVFile(object):
         if num_remove_ids <= 0:
             return
 
-        print(output)
+        print(output, flush=True)
 
         # Add source mkv file to command and remux
         command.append(self.path)

--- a/mkvstrip.py
+++ b/mkvstrip.py
@@ -238,7 +238,12 @@ class MKVFile(object):
         # Process the json response
         json_data = json.loads(stdout)
         track_map = {"video": self.video_tracks, "audio": self.audio_tracks, "subtitles": self.subtitle_tracks}
-        for track_data in json_data["tracks"]:
+        tracks = json_data.get("tracks")
+        if not tracks:
+            print(f"No tracks for {path}")
+            print("Might not be a valid movie.")
+            return
+        for track_data in tracks:
             track_obj = Track(track_data)
             track_map[track_obj.type].append(track_obj)
 

--- a/mkvstrip.py
+++ b/mkvstrip.py
@@ -413,9 +413,9 @@ def strip_tree(path):
             # No sophisticated traversal search.
             timestamp = os.stat(timestamp_fn).st_mtime
             timestamp_dt = datetime.datetime.fromtimestamp(timestamp)
-            print(f"Found mkvstrip timestamp from {timestamp_dt}")
+            print(f"Found mkvstrip timestamp in {dirname} from {timestamp_dt}")
         else:
-            print("No mkvstrip timestamp found.")
+            print("No mkvstrip timestamp found in {dirname}.")
         sys.stdout.flush()
 
 
@@ -437,7 +437,7 @@ def strip_tree(path):
         else:
             with open(timestamp_fn, 'a'):
                 pass
-        print("Set mkvstrip timestamp.")
+        print(f"Set mkvstrip timestamp in {path}.")
 
 @catch_interrupt
 def main(params=None):

--- a/mkvstrip.py
+++ b/mkvstrip.py
@@ -329,7 +329,7 @@ class MKVFile(object):
                 output += "Retaining %s track(s):\n" % track_type
                 for count, track in enumerate(keep):
                     keep_ids.append(str(track.id))
-                    output += "   " + track + "\n"
+                    output += "   %s\n" % track
 
                     # Set the first track as default
                     command.extend(["--default-track", ":".join((str(track.id), "0" if count else "1"))])

--- a/mkvstrip.py
+++ b/mkvstrip.py
@@ -334,7 +334,7 @@ class MKVFile(object):
                 output += "Retaining %s track(s):\n" % track_type
                 for count, track in enumerate(keep):
                     keep_ids.append(str(track.id))
-                    output += "   %s\n" % track
+                    output += f"   {track}\n"
 
                     # Set the first track as default
                     command.extend(["--default-track", ":".join((str(track.id), "0" if count else "1"))])
@@ -351,7 +351,7 @@ class MKVFile(object):
                 # This is just here to report what tracks will be removed
                 output += "Removing %s track(s):\n" % track_type
                 for track in remove:
-                    print("   ", track)
+                    output += f"   {track}\n"
 
                 output += "----------------------------\n"
 

--- a/mkvstrip.py
+++ b/mkvstrip.py
@@ -306,8 +306,8 @@ class MKVFile(object):
         """Remove the unwanted tracks."""
         # The command line args required to remux the mkv file
         command = [cli_args.mkvmerge_bin, "--output"]
-        print("\nRemuxing:", self.filename)
-        print("============================")
+        output = "\nRemuxing: " + self.filename + "\n"
+        output += "============================\n"
 
         # Output the remuxed file to a temp tile, This will protect
         # the original file from been currupted if anything goes wrong
@@ -316,16 +316,17 @@ class MKVFile(object):
         command.extend(["--title", self.filename[:-4]])
 
         # Iterate all tracks and mark which tracks are to be kepth
+        num_remove_ids = 0
         for track_type in ("audio", "subtitle"):
             keep, remove = self._filtered_tracks(track_type)
             if ((track_type == "subtitle" and cli_args.no_subtitles)
                     or keep) and remove:
                 keep_ids = []
 
-                print("Retaining %s track(s):" % track_type)
+                output += "Retaining %s track(s):\n" % track_type
                 for count, track in enumerate(keep):
                     keep_ids.append(str(track.id))
-                    print("   ", track)
+                    output += "   " + track + "\n"
 
                     # Set the first track as default
                     command.extend(["--default-track", ":".join((str(track.id), "0" if count else "1"))])
@@ -337,12 +338,19 @@ class MKVFile(object):
                 elif track_type == "subtitle":
                     command.extend(["--no-subtitles"])
 
+                num_remove_ids += len(remove)
+
                 # This is just here to report what tracks will be removed
-                print("Removing %s track(s):" % track_type)
+                output += "Removing %s track(s):\n" % track_type
                 for track in remove:
                     print("   ", track)
 
-                print("----------------------------")
+                output += "----------------------------\n"
+
+        if num_remove_ids <= 0:
+            return
+
+        print(output)
 
         # Add source mkv file to command and remux
         command.append(self.path)


### PR DESCRIPTION
A fork of the "nudebomb" branch that does recursive stripping, but includes an option for setting timestamps in root directories. Timestamps can prevent mkvstrip from using an expensive mkvmerge subprocess to inspect files that haven't changed since the last mkvstrip -r run. 

This can process directory trees with thousands of files in under a second if there are no changes.

I've written other programs with sophisticated timestamp searching up and down directory trees. This is not that. This only looks for timestamps in root directories specified on the command line.